### PR TITLE
Fixed duplicated enrollment bug

### DIFF
--- a/src/entities/Enrollment.ts
+++ b/src/entities/Enrollment.ts
@@ -52,6 +52,8 @@ export default class Enrollment extends BaseEntity {
       throw new CpfNotAvailableError(data.cpf);
     }
 
+    enrollment = await this.findOne({ where: { userId: data.userId } });
+
     enrollment ||= Enrollment.create();
     enrollment.populateFromData(data);
     await enrollment.save();


### PR DESCRIPTION
O problema é que a linha 49 de entities/Enrollment.ts busca na database pelo CPF enviado pela requisição.
Mas se o úsuário mudou o campo de cpf, a busca não vai encontrar o cpf antigo e criará uma nova entrada.