### PR TITLE
Fixe ticket/ticket_types relation

### DIFF
--- a/src/entities/Ticket.ts
+++ b/src/entities/Ticket.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, Entity, PrimaryGeneratedColumn, Column, OneToOne, JoinColumn } from "typeorm";
+import { BaseEntity, Entity, PrimaryGeneratedColumn, Column, OneToOne, JoinColumn, ManyToOne } from "typeorm";
 import Enrollment from "./Enrollment";
 import TicketType from "./TicketType";
 import TicketData from "@/interfaces/ticket";
@@ -18,7 +18,7 @@ export default class Ticket extends BaseEntity {
   @JoinColumn({ name: "enrollment_id" })
   enrollmentId: number;
 
-  @OneToOne(() => TicketType, (ticketType) => ticketType.id, { eager: true })
+  @ManyToOne(() => TicketType, (ticketType) => ticketType.id, { eager: true })
   @JoinColumn({ name: "tickets_type_id" })
   ticketsTypeId: number;
 

--- a/src/migrations/1642967414491-FixedTicketsTicketTypesRelation.ts
+++ b/src/migrations/1642967414491-FixedTicketsTicketTypesRelation.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FixedTicketsTicketTypesRelation1642967414491 implements MigrationInterface {
+    name = "FixedTicketsTicketTypesRelation1642967414491"
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query("ALTER TABLE \"enrollments\" DROP COLUMN \"roomId\"");
+      await queryRunner.query("ALTER TABLE \"tickets\" DROP CONSTRAINT \"FK_59dd44a1afada41f1531b06d133\"");
+      await queryRunner.query("ALTER TABLE \"tickets\" DROP CONSTRAINT \"UQ_59dd44a1afada41f1531b06d133\"");
+      await queryRunner.query("ALTER TABLE \"tickets\" ADD CONSTRAINT \"FK_59dd44a1afada41f1531b06d133\" FOREIGN KEY (\"tickets_type_id\") REFERENCES \"ticket_types\"(\"id\") ON DELETE NO ACTION ON UPDATE NO ACTION");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query("ALTER TABLE \"tickets\" DROP CONSTRAINT \"FK_59dd44a1afada41f1531b06d133\"");
+      await queryRunner.query("ALTER TABLE \"tickets\" ADD CONSTRAINT \"UQ_59dd44a1afada41f1531b06d133\" UNIQUE (\"tickets_type_id\")");
+      await queryRunner.query("ALTER TABLE \"tickets\" ADD CONSTRAINT \"FK_59dd44a1afada41f1531b06d133\" FOREIGN KEY (\"tickets_type_id\") REFERENCES \"ticket_types\"(\"id\") ON DELETE NO ACTION ON UPDATE NO ACTION");
+      await queryRunner.query("ALTER TABLE \"enrollments\" ADD \"roomId\" integer");
+    }
+}


### PR DESCRIPTION
Corrigi o problema que não permite vários usuários reservarem o mesmo tipo de ticket.
A coluna ticket_type_id da tabela ticket estava setada como UNIQUE.